### PR TITLE
fix clarifai App usage

### DIFF
--- a/vendors/clarifai_.py
+++ b/vendors/clarifai_.py
@@ -3,7 +3,7 @@ from clarifai.rest import Image as ClImage
 
 
 def call_vision_api(image_filename, api_keys):
-    app = ClarifaiApp()
+    app = ClarifaiApp(api_key=api_keys['clarifai']['api_key'])
     model = app.models.get('general-v1.3')
     image = ClImage(file_obj=open(image_filename, 'rb'))
     result = model.predict([image])


### PR DESCRIPTION
ClarifAI app accepts API key as argument in the constructor. I think that is better than putting the key in a `~/.clarifai/config` file. This way all configs can be in one place.