### PR TITLE
python 2/3 compatibility

### DIFF
--- a/cloudy_vision.py
+++ b/cloudy_vision.py
@@ -176,7 +176,7 @@ def process_all_images():
                 copyfile(filepath, output_image_filepath)
 
         # Walk through all vendor APIs to call.
-        for vendor_name, vendor_module in sorted(settings('vendors').iteritems(), reverse=True):
+        for vendor_name, vendor_module in sorted(settings('vendors').items(), reverse=True):
 
             # Figure out filename to store and retrive cached JSON results.
             output_json_filename = filename + "." + vendor_name + ".json"
@@ -257,7 +257,7 @@ def process_all_images():
     # Write HTML output.
     output_html_filepath = os.path.join(settings('output_dir'), 'output.html')
     with open(output_html_filepath, 'w') as output_html_file:
-        output_html_file.write(output_html.encode('utf-8'))
+        output_html_file.write(output_html)
 
 
 if __name__ == "__main__":

--- a/static/template.html
+++ b/static/template.html
@@ -76,7 +76,7 @@
                 </span>
             </td>
           </tr>
-          {% for feature_name, feature_results in vendor['standardized_result'].iteritems() %}
+          {% for feature_name, feature_results in vendor['standardized_result'].items() %}
           <tr>
               <td class="result_name">
                   {{ vendor['vendor_name'] }}_{{ feature_name }}
@@ -135,7 +135,7 @@
                 On time taken, and number of tags returned. Note that Cloudsight returns captions, not a list of tags, so those counts appear as zero.
             </p>
             <table class="u-full-width">
-                {% for vendor, stats in vendor_stats.iteritems() %}
+                {% for vendor, stats in vendor_stats.items() %}
                 {% if loop.first %}
                 <tr class="raw_json">
                     <td class="result_name">Vendor</td>

--- a/vendors/clarifai_.py
+++ b/vendors/clarifai_.py
@@ -23,6 +23,6 @@ def get_standardized_result(api_result):
         tag_names.append(concept['name'])
         tag_scores.append(concept['value'])
 
-    output['tags'] = zip(tag_names, tag_scores)
+    output['tags'] = list(zip(tag_names, tag_scores))
 
     return output

--- a/vendors/clarifai_.py
+++ b/vendors/clarifai_.py
@@ -3,7 +3,7 @@ from clarifai.rest import Image as ClImage
 
 
 def call_vision_api(image_filename, api_keys):
-    app = ClarifaiApp()
+    app = ClarifaiApp(api_key=api_keys['clarifai']['api_key'])
     model = app.models.get('general-v1.3')
     image = ClImage(file_obj=open(image_filename, 'rb'))
     result = model.predict([image])

--- a/vendors/cloudsight_.py
+++ b/vendors/cloudsight_.py
@@ -1,8 +1,8 @@
 import cloudsight
 
+
 def call_vision_api(image_filename, api_keys):
     api_key = api_keys['cloudsight']['api_key']
-    api_secret = api_keys['cloudsight']['api_secret']
 
     # Via example found here:
     # https://github.com/cloudsight/cloudsight-python
@@ -14,19 +14,20 @@ def call_vision_api(image_filename, api_keys):
         response = api.image_request(image_file, image_filename)
 
     response = api.wait(response['token'], timeout=60)
-    
+
     return response
 
 
 def get_standardized_result(api_result):
     output = {
-        'captions' : [],
+        'captions': [],
     }
 
     if api_result['status'] == 'completed':
         output['captions'].append((api_result["name"], None))
     elif api_result['status'] == 'skipped':
-        output['captions'].append(("error_skipped_because_" + api_result["reason"], None))
+        output['captions'].append(
+            ("error_skipped_because_" + api_result["reason"], None))
     else:
         output['captions'].append(("error_" + api_result["status"], None))
 

--- a/vendors/google.py
+++ b/vendors/google.py
@@ -2,48 +2,51 @@ import base64
 import json
 import requests
 
+
 def _convert_image_to_base64(image_filename):
     with open(image_filename, 'rb') as image_file:
         encoded_string = base64.b64encode(image_file.read()).decode()
 
     return encoded_string
 
+
 def call_vision_api(image_filename, api_keys):
     api_key = api_keys['google']
-    post_url = "https://vision.googleapis.com/v1/images:annotate?key=" + api_key
+    post_url = "https://vision.googleapis.com/v1/images:annotate?key="\
+        + api_key
 
     base64_image = _convert_image_to_base64(image_filename)
 
     post_payload = {
-      "requests": [
-        {
-          "image": {
-            "content" : base64_image
-          },
-          "features": [
+        "requests": [
             {
-              "type": "LABEL_DETECTION",
-              "maxResults": 10
-            },
-            {
-              "type": "FACE_DETECTION",
-              "maxResults": 10
-            },
-            {
-              "type": "LANDMARK_DETECTION",
-              "maxResults": 10
-            },
-            {
-              "type": "LOGO_DETECTION",
-              "maxResults": 10
-            },
-            {
-              "type": "SAFE_SEARCH_DETECTION",
-              "maxResults": 10
-            },
-          ]
-        }
-      ]
+                "image": {
+                    "content": base64_image
+                },
+                "features": [
+                    {
+                        "type": "LABEL_DETECTION",
+                        "maxResults": 10
+                    },
+                    {
+                        "type": "FACE_DETECTION",
+                        "maxResults": 10
+                    },
+                    {
+                        "type": "LANDMARK_DETECTION",
+                        "maxResults": 10
+                    },
+                    {
+                        "type": "LOGO_DETECTION",
+                        "maxResults": 10
+                    },
+                    {
+                        "type": "SAFE_SEARCH_DETECTION",
+                        "maxResults": 10
+                    },
+                ]
+            }
+        ]
     }
 
     result = requests.post(post_url, json=post_payload)
@@ -55,7 +58,7 @@ def call_vision_api(image_filename, api_keys):
 # See this function in microsoft.py for docs.
 def get_standardized_result(api_result):
     output = {
-        'tags' : [],
+        'tags': [],
     }
 
     api_result = api_result['responses'][0]
@@ -69,6 +72,7 @@ def get_standardized_result(api_result):
     if 'logoAnnotations' in api_result:
         output['logo_tags'] = []
         for annotation in api_result['logoAnnotations']:
-            output['logo_tags'].append((annotation['description'], annotation['score']))
+            output['logo_tags'].append(
+                (annotation['description'], annotation['score']))
 
     return output

--- a/vendors/ibm.py
+++ b/vendors/ibm.py
@@ -1,5 +1,6 @@
 from watson_developer_cloud import VisualRecognitionV3
 
+
 def call_vision_api(image_filename, api_keys):
     api_key = api_keys['ibm']
 
@@ -15,7 +16,7 @@ def call_vision_api(image_filename, api_keys):
 
 def get_standardized_result(api_result):
     output = {
-        'tags' : [],
+        'tags': [],
     }
 
     api_result = api_result["images"][0]

--- a/vendors/microsoft.py
+++ b/vendors/microsoft.py
@@ -1,17 +1,26 @@
 import json
 import requests
 
+
 def call_vision_api(image_filename, api_keys):
     api_key = api_keys['microsoft']
-    post_url = "https://api.projectoxford.ai/vision/v1.0/analyze?visualFeatures=Categories,Tags,Description,Faces,ImageType,Color,Adult&subscription-key=" + api_key
+    post_url = "https://api.projectoxford.ai/vision/v1.0/analyze?"\
+               "visualFeatures=Categories,Tags,Description,Faces,"\
+               "ImageType,Color,Adult&subscription-key=" + api_key
 
     image_data = open(image_filename, 'rb').read()
-    result = requests.post(post_url, data=image_data, headers={'Content-Type': 'application/octet-stream'})
+    with open(image_filename, 'rb') as f:
+        image_data = f.read()
+
+    headers = {'Content-Type': 'application/octet-stream'}
+    result = requests.post(post_url, data=image_data, headers=headers)
     result.raise_for_status()
 
     return json.loads(result.text)
 
-# Return a dictionary of features to their scored values (represented as lists of tuples).
+
+# Return a dictionary of features to their scored values
+# (represented as lists of tuples).
 # Scored values must be sorted in descending order.
 #
 # {
@@ -28,12 +37,12 @@ def call_vision_api(image_filename, api_keys):
 #
 def get_standardized_result(api_result):
     output = {
-        'tags' : [],
-        'captions' : [],
-#        'categories' : [],
-#        'adult' : [],
-#        'image_types' : []
-#        'tags_without_score' : {}
+        'tags': [],
+        'captions': [],
+        # 'categories': [],
+        # 'adult': [],
+        # 'image_types': [],
+        # 'tags_without_score': {}
     }
 
     for tag_data in api_result['tags']:
@@ -42,14 +51,14 @@ def get_standardized_result(api_result):
     for caption in api_result['description']['captions']:
         output['captions'].append((caption['text'], caption['confidence']))
 
-#    for category in api_result['categories']:
-#        output['categories'].append(([category['name'], category['score']))
+    # for category in api_result['categories']:
+    #     output['categories'].append(([category['name'], category['score']))
 
-#    output['adult'] = api_result['adult']
+    # output['adult'] = api_result['adult']
 
-#    for tag in api_result['description']['tags']:
-#        output['tags_without_score'][tag] = 'n/a'
+    # for tag in api_result['description']['tags']:
+    #     output['tags_without_score'][tag] = 'n/a'
 
-#    output['image_types'] = api_result['imageType']
+    # output['image_types'] = api_result['imageType']
 
     return output

--- a/vendors/rekognition.py
+++ b/vendors/rekognition.py
@@ -1,5 +1,6 @@
 import boto3
 
+
 def call_vision_api(image_filename, api_keys):
     client = boto3.client('rekognition')
 
@@ -10,13 +11,14 @@ def call_vision_api(image_filename, api_keys):
 
 def get_standardized_result(api_result):
     output = {
-        'tags' : [],
+        'tags': [],
     }
     if 'Labels' not in api_result:
         return output
 
     labels = api_result['Labels']
     for tag in labels:
-        output['tags'].append((tag['Name'], tag['Confidence']/100))
+        output['tags'].append(
+            (tag['Name'], tag['Confidence'] / 100.0))
 
     return output


### PR DESCRIPTION
I made changes to make this code both python2 and python3 compatible. I replaced the `iteritems` with `items` - it doesn't do the same thing, but for very small lists (as the ones in this code) performance impact is insignificant. And of course, results are equal.
Also added list in front of `zip` to make in work in python3 (where zip returns a iterable `ZipObject`).